### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,6 +3,9 @@
 
 name: Python
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/dataresearchcenter/ftmq/security/code-scanning/7](https://github.com/dataresearchcenter/ftmq/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root (best single change) so all jobs inherit least-privilege defaults.  
For this workflow, `contents: read` is the minimal safe baseline and aligns with CodeQL’s recommendation. This does not change intended functionality in typical CI usage and documents security expectations clearly.

**Where to change:** `.github/workflows/python.yml`, directly after `name: Python` (before `on:`).

**What to add:**
```yml
permissions:
  contents: read
```

No imports/methods/dependencies are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
