### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/test_fragment_store.py
+++ b/tests/test_fragment_store.py
@@ -1,6 +1,6 @@
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 from followthemoney import EntityProxy


### PR DESCRIPTION
To fix an unused import warning, remove only the unused symbol from the import statement while keeping all used imports intact. Here, in `tests/test_fragment_store.py`, line 3 should be changed from importing both `datetime` and `timedelta` to importing only `datetime`.

Best single fix (no functionality change):
- Edit `tests/test_fragment_store.py`
- Update the import line:
  - `from datetime import datetime, timedelta`
  - to `from datetime import datetime`
- No new imports, methods, or variable definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._